### PR TITLE
Do not select item if null/undefined is provided as item

### DIFF
--- a/src/VSuperSelect.vue
+++ b/src/VSuperSelect.vue
@@ -259,6 +259,10 @@ export default Vue.extend({
         return
       }
 
+      if(!item) {
+        return;
+      }
+
       if (focus) {
         const f = (this.$refs.input as HTMLElement).focus()
       }


### PR DESCRIPTION
I found out that null was being passed when the user presses Escape key which in turn was creating an error on line 276 because it was trying to access a property of null. 